### PR TITLE
Require min version (`^0.1.0`) of shiny-bindings-core

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {},
   "dependencies": {
-    "@posit-dev/shiny-bindings-core": "*",
+    "@posit-dev/shiny-bindings-core": "^0.1.0",
     "@types/react": "^18.2.38",
     "@types/react-dom": "^18.2.16",
     "react": "^18.2.0",


### PR DESCRIPTION
Had installed old version of shiny-bindings-react. Updated to v0.1.0. It had previously installed `v0.0.2` core which was compatible with `*`. However, I could not install shiny-bindings-react until I cleared my node_modules.