### PR TITLE
feat: ability to pass props to the react component

### DIFF
--- a/packages/demo-pkg/custom_component/distjs/index.js
+++ b/packages/demo-pkg/custom_component/distjs/index.js
@@ -23671,7 +23671,10 @@
       selector,
       setup: (el, updateValue) => {
         updateValue(initialValue);
+        const props = JSON.parse(el.dataset.props || "{}");
+        delete el.dataset.props;
         (0, import_client.createRoot)(el).render(renderComp({
+          ...props,
           initialValue,
           updateValue: (x2) => updateValue(x2, priority === "deferred")
         }));
@@ -23714,19 +23717,16 @@
           padding: "1rem"
         }
       },
-      "I'm a react output with value ",
+      "I am a react output with value: ",
       /* @__PURE__ */ import_react.default.createElement("strong", null, value)
     )
   });
   makeReactInput({
     name: "custom-react-input",
     initialValue: 0,
-    renderComp: ({ initialValue, updateValue }) => /* @__PURE__ */ import_react.default.createElement(MyInput, { value: initialValue, updateValue })
+    renderComp: (props) => /* @__PURE__ */ import_react.default.createElement(MyInput, { ...props })
   });
-  function MyInput({
-    value,
-    updateValue
-  }) {
+  function MyInput({ label, value, updateValue }) {
     const [val, setVal] = import_react.default.useState(value);
     return /* @__PURE__ */ import_react.default.createElement(import_react.default.Fragment, null, /* @__PURE__ */ import_react.default.createElement(
       "button",
@@ -23737,7 +23737,7 @@
           updateValue(newVal);
         }
       },
-      "React"
+      label
     ));
   }
 

--- a/packages/demo-pkg/custom_component/react_components.py
+++ b/packages/demo-pkg/custom_component/react_components.py
@@ -1,17 +1,18 @@
-from htmltools import Tag
+import json
 
+from htmltools import Tag, TagAttrValue
 from shiny.module import resolve_id
 
 from .custom_component import custom_component_deps
 
 
-def react_input(id: str):
+def react_input(id: str, **kwargs: TagAttrValue):
     """
     A react output.
     """
     return Tag(
         "div",
-        {"class": "custom-react-input"},
+        {"class": "custom-react-input", "data-props": json.dumps(kwargs)},
         custom_component_deps,
         # Use resolve_id so that our component will work in a module
         id=resolve_id(id),

--- a/packages/demo-pkg/example-app/app.py
+++ b/packages/demo-pkg/example-app/app.py
@@ -18,7 +18,7 @@ app_ui = ui.page_fluid(
     ),
     ui.card(
         ui.card_header("React"),
-        react_input("reactInput"),
+        react_input("reactInput", label="Hello from Python!"),
         react_output("reactOutput"),
     ),
     ui.card(

--- a/packages/demo-pkg/srcts/react-components.tsx
+++ b/packages/demo-pkg/srcts/react-components.tsx
@@ -20,21 +20,19 @@ makeReactOutput<Payload>({
   ),
 });
 
-makeReactInput<number>({
-  name: "custom-react-input",
-  initialValue: 0,
-  renderComp: ({ initialValue, updateValue }) => (
-    <MyInput value={initialValue} updateValue={updateValue} />
-  ),
-});
-
-function MyInput({
-  value,
-  updateValue,
-}: {
+interface MyInputProps {
+  label: string;
   value: number;
   updateValue: (val: number) => void;
-}) {
+}
+
+makeReactInput<number, MyInputProps>({
+  name: "custom-react-input",
+  initialValue: 0,
+  renderComp: (props) => <MyInput {...props} />,
+});
+
+function MyInput({ label, value, updateValue }: MyInputProps) {
   const [val, setVal] = React.useState(value);
 
   return (
@@ -46,7 +44,7 @@ function MyInput({
           updateValue(newVal);
         }}
       >
-        React
+        {label}
       </button>
     </>
   );

--- a/packages/react/src/makeReactInput.ts
+++ b/packages/react/src/makeReactInput.ts
@@ -11,7 +11,7 @@ import { createRoot } from "react-dom/client";
  * @param renderComp A function that renders the react component into the custom element
  * @param priority Should the value be immediately updated wait to the next even loop? Typically set at "immediate."
  */
-export function makeReactInput<T>({
+export function makeReactInput<T, P extends Object>({
   name,
   selector,
   initialValue,
@@ -21,13 +21,10 @@ export function makeReactInput<T>({
   name: string;
   selector?: string;
   initialValue: T;
-  renderComp: ({
-    initialValue,
-    updateValue,
-  }: {
+  renderComp: (props: {
     initialValue: T;
     updateValue: (x: T) => void;
-  }) => ReactNode;
+  } & P) => ReactNode;
   priority?: "immediate" | "deferred";
 }) {
   makeInputBinding<T>({
@@ -37,8 +34,15 @@ export function makeReactInput<T>({
       // Fire off onNewValue with the initial value
       updateValue(initialValue);
 
+      // Get the component props from `data-props` attribute
+      const props = JSON.parse(el.dataset.props || "{}");
+
+      // Remove the `data-props` attribute to keep the DOM clean
+      delete el.dataset.props
+
       createRoot(el).render(
         renderComp({
+          ...props,
           initialValue: initialValue,
           updateValue: (x) => updateValue(x, priority === "deferred"),
         })


### PR DESCRIPTION
Make it possible to pass props to a React component from Python code.

Component properties are defined in Python, serialized to a dictionary, and sent to the DOM via `data-props` HTML attribute.

`makeReactInput` function receives those props, parses and sends them further to the React component. This is possible thanks to a second generic parameter which defines the shape of the props.

To showcase this new feature, the `demo-pkg` code is updated accordingly.